### PR TITLE
feat: adding the background image and background color

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,16 @@
                         <label for="colorPicker" class="text-light">Color :</label>
                         <input type="color" name="colorPicker" class="rounded " id="colorPicker">
                     </div>
+                    <!-- added feature - Background -->
+                    <div class="d-flex gap-3 px-3">
+                        <!-- Background Image Upload -->
+                        <label for="bgImageUpload" class="text-light">Background Image:</label>
+                        <input type="file" id="bgImageUpload" accept="image/*">
+                        <!-- Background Color Picker -->
+                        <label for="bgColorPicker" class="text-light">Background Color:</label>
+                        <input type="color" id="bgColorPicker" class="rounded">
+                    </div>                    
                     <div class="d-md-flex justify-content-evenly gap-1">
-                        <!-- added features -->
                         <button class="btn btn-primary" id="capital">A</button>
                         <button class="btn btn-primary" id="small">a</button>
                         <button class="btn btn-primary" id="bold">
@@ -60,7 +68,7 @@
                     <div class="d-md-flex justify-content-center gap-1">
                         <input type="text" placeholder="Enter Text " name="textData" id="textData" class="form-control mw-100 w-75 fullWidth">
                         <button class="btn btn-primary">Save</button>
-                        <!-- added features -->
+                        
                         <button class="btn btn-primary" id="clear">clear</button>
                         <button type="button" class="btn btn-primary" id="download" title="Download">
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-download" viewBox="0 0 16 16">

--- a/src/Scripts/Canvas.js
+++ b/src/Scripts/Canvas.js
@@ -210,3 +210,31 @@ italicButton.addEventListener('click', (e) => {
     isItalic = !isItalic; // Toggle italic
     updateCanvas(textVal, fontSize, defaultColor, posX, posY); // Update the canvas
 });
+let bgColorPicker = document.getElementById('bgColorPicker');
+
+bgColorPicker.addEventListener('input', function() {
+    const bgColor = bgColorPicker.value;
+    myCanvas.clearRect(0, 0, cWidth, cHeight);  // Clear previous background
+    myCanvas.fillStyle = bgColor;
+    myCanvas.fillRect(0, 0, cWidth, cHeight);  // Apply new background color
+});
+
+
+// Handle background image upload
+bgImageUpload.addEventListener('change', function(event) {
+    const file = event.target.files[0];
+    if (file) {
+        const img = new Image();
+        const reader = new FileReader();
+
+        reader.onload = function(e) {
+            img.src = e.target.result;
+            img.onload = function() {
+                myCanvas.clearRect(0, 0, mainCanvas.width, mainCanvas.height);  // Clear previous background
+                myCanvas.drawImage(img, 0, 0, mainCanvas.width, mainCanvas.height);  // Draw the image on canvas
+            };
+        };
+        reader.readAsDataURL(file);
+    }
+});
+


### PR DESCRIPTION
Fixes: #13

option to canvas
# Pull Request Format
## PR Naming
##Issue #0 : **To add background to canvas #21** solved
## Type of PR
Add X in the box to specify the improvement type.
 -[x] Bug fix
 -[x] Feature enhancement
Description
This pull request aims to so here I have added the background image and Background color option 

Screenshots / Videos (if applicable)
# Before:
![image](https://github.com/user-attachments/assets/77b8bf63-2f32-4439-9db4-85e8344eb27b)
We where having only one color canvas(white)

# After:
![image](https://github.com/user-attachments/assets/b7d63a14-a041-40ad-88a4-e8dbdef0a333)
![image](https://github.com/user-attachments/assets/35eb7699-8f5f-42da-911b-2786a36e1f3f)

Now there is option of background image and background color .
Here we have the color full canvas 


# Checklist
Add X in the box to specify.
 -[x] I have performed a self-review of my code.
 -[x] I have tested the changes thoroughly before submitting this pull request.
 -[x] I have provided relevant issue numbers, screenshots after making the changes.

Thank you for reviewing my pull request!