### PR TITLE
Add support for multiple text elements on canvas #26 UPDATE

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,11 @@
         </div>
         
         <div class="d-md-flex justify-content-center gap-3 align-items-center flex-column flex-md-row">
+
             <canvas id="mainCanvas" class="h-80 h-80-responsive border border-gray shadow rounded" onclick="dragContentStart(event)" onmousemove="dragContent(event)">
                 Canvas Not Supported by the Browser...
             </canvas>
+            
             <div class="h-80 h-80-responsive p-1 bg-dark rounded w-100 shadow">
                 <form id="userForm" class="h-80 h-80-responsive d-flex flex-column justify-content-evenly">
                     <div class="d-flex gap-3 px-3">
@@ -38,9 +40,12 @@
                         <label for="colorPicker" class="text-light">Color :</label>
                         <input type="color" name="colorPicker" class="rounded" id="colorPicker">
                     </div>
+                    <!-- added feature - Background -->
                     <div class="d-flex gap-3 px-3">
+                        <!-- Background Image Upload -->
                         <label for="bgImageUpload" class="text-light">Background Image:</label>
                         <input type="file" id="bgImageUpload" accept="image/*">
+                        <!-- Background Color Picker -->
                         <label for="bgColorPicker" class="text-light">Background Color:</label>
                         <input type="color" id="bgColorPicker" class="rounded">
                     </div>                    
@@ -60,12 +65,15 @@
                     </div>
                     <div class="d-md-flex justify-content-center gap-1">
                         <input type="text" placeholder="Enter Text " name="textData" id="textData" class="form-control mw-100 w-75 fullWidth">
+
                         <button type="submit" class="btn btn-primary">Save</button>
+                        <!-- added features -->
+
                         <button class="btn btn-primary" id="clear">clear</button>
                         <button type="button" class="btn btn-primary" id="download" title="Download">
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-download" viewBox="0 0 16 16">
                                 <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5"/>
-                                <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L4.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
+                                <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708z"/>
                             </svg>
                         </button>
                     </div>
@@ -73,7 +81,8 @@
             </div>
         </div>
     </div>
-    <script src="./src/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="./src/scripts/script.js"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="./src/Scripts/Canvas.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -28,11 +27,9 @@
         </div>
         
         <div class="d-md-flex justify-content-center gap-3 align-items-center flex-column flex-md-row">
-
             <canvas id="mainCanvas" class="h-80 h-80-responsive border border-gray shadow rounded" onclick="dragContentStart(event)" onmousemove="dragContent(event)">
                 Canvas Not Supported by the Browser...
             </canvas>
-            
             <div class="h-80 h-80-responsive p-1 bg-dark rounded w-100 shadow">
                 <form id="userForm" class="h-80 h-80-responsive d-flex flex-column justify-content-evenly">
                     <div class="d-flex gap-3 px-3">
@@ -41,12 +38,9 @@
                         <label for="colorPicker" class="text-light">Color :</label>
                         <input type="color" name="colorPicker" class="rounded" id="colorPicker">
                     </div>
-                    <!-- added feature - Background -->
                     <div class="d-flex gap-3 px-3">
-                        <!-- Background Image Upload -->
                         <label for="bgImageUpload" class="text-light">Background Image:</label>
                         <input type="file" id="bgImageUpload" accept="image/*">
-                        <!-- Background Color Picker -->
                         <label for="bgColorPicker" class="text-light">Background Color:</label>
                         <input type="color" id="bgColorPicker" class="rounded">
                     </div>                    
@@ -66,15 +60,12 @@
                     </div>
                     <div class="d-md-flex justify-content-center gap-1">
                         <input type="text" placeholder="Enter Text " name="textData" id="textData" class="form-control mw-100 w-75 fullWidth">
-
                         <button type="submit" class="btn btn-primary">Save</button>
-                        <!-- added features -->
-
                         <button class="btn btn-primary" id="clear">clear</button>
                         <button type="button" class="btn btn-primary" id="download" title="Download">
                             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-download" viewBox="0 0 16 16">
                                 <path d="M.5 9.9a.5.5 0 0 1 .5.5v2.5a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-2.5a.5.5 0 0 1 1 0v2.5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2v-2.5a.5.5 0 0 1 .5-.5"/>
-                                <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L5.354 8.146a.5.5 0 1 0-.708.708z"/>
+                                <path d="M7.646 11.854a.5.5 0 0 0 .708 0l3-3a.5.5 0 0 0-.708-.708L8.5 10.293V1.5a.5.5 0 0 0-1 0v8.793L4.354 8.146a.5.5 0 1 0-.708.708l3 3z"/>
                             </svg>
                         </button>
                     </div>
@@ -82,8 +73,7 @@
             </div>
         </div>
     </div>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="./src/Scripts/Canvas.js"></script>
+    <script src="./src/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="./src/scripts/script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -86,3 +86,4 @@
     <script src="./src/Scripts/Canvas.js"></script>
 </body>
 </html>
+

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -23,6 +24,7 @@
                     <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466"/>
                 </svg>
             </button>
+            <button class="btn btn-primary" id="addText">Add Text</button>
         </div>
         
         <div class="d-md-flex justify-content-center gap-3 align-items-center flex-column flex-md-row">
@@ -85,4 +87,3 @@
     <script src="./src/Scripts/Canvas.js"></script>
 </body>
 </html>
-

--- a/src/Scripts/Canvas.js
+++ b/src/Scripts/Canvas.js
@@ -53,28 +53,73 @@ let SnapSorts = [firstElement];
 
 let index = 0;
 
-let addToSnapSorts = (textVal, font, defaultColor, x, y) => {
-    let SnapElement = new SnapSortsClass(textVal, font, defaultColor, x, y);
-    SnapSorts.push(SnapElement);
+// New array to store multiple text elements
+let textElements = [];
+
+// Modify addToSnapSorts to handle multiple elements
+let addToSnapSorts = () => {
+    let snapshot = textElements.map(el => new SnapSortsClass(el.text, el.font, el.color, el.x, el.y));
+    SnapSorts.push(snapshot);
     index++;
 };
 
+// New function to add text element
+let addTextElement = (text, font, color, x, y) => {
+    textElements.push({ text, font, color, x, y });
+    renderAllElements();
+};
+
+// New function to render all elements
+let renderAllElements = () => {
+    myCanvas.clearRect(0, 0, cWidth, cHeight);
+    textElements.forEach(el => {
+        myCanvas.font = el.font;
+        myCanvas.fillStyle = el.color;
+        myCanvas.fillText(el.text, el.x, el.y);
+    });
+};
+
+// Modify updateCanvas to use renderAllElements
 let updateCanvas = (text, tSize, color, x, y) => {
     fontSize = tSize;
     defaultColor = color;
-    // Update canvasFont to include bold and italic if selected
     canvasFont = `${isBold ? 'bold ' : ''}${isItalic ? 'italic ' : ''}${fontSize}px ${fontName}`;
 
-    myCanvas.clearRect(0, 0, cWidth, cHeight);
-    myCanvas.font = canvasFont;
-    myCanvas.fillStyle = defaultColor;
-    myCanvas.fillText(text, x, y);
+    // Update the current text element or add a new one
+    if (textElements.length > 0) {
+        textElements[textElements.length - 1] = { text, font: canvasFont, color, x, y };
+    } else {
+        addTextElement(text, canvasFont, color, x, y);
+    }
+
+    renderAllElements();
 
     localStorage.setItem('pos-x', x);
     localStorage.setItem('pos-y', y);
     localStorage.setItem('font-size', fontSize);
     localStorage.setItem('font-color', defaultColor);
 };
+
+// Modify userForm event listener
+userForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    textVal = e.target.textData.value;
+    canvasFont = `${isBold ? 'bold ' : ''}${isItalic ? 'italic ' : ''}${fontSize}px ${fontName}`;
+    defaultColor = e.target.colorPicker.value;
+    addTextElement(textVal, canvasFont, defaultColor, posX, posY);
+    addToSnapSorts();
+    print(SnapSorts);
+});
+
+// New button for adding text
+let addTextButton = document.getElementById('addText');
+addTextButton.addEventListener('click', (e) => {
+    e.preventDefault();
+    textVal = document.getElementById('textData').value;
+    canvasFont = `${isBold ? 'bold ' : ''}${isItalic ? 'italic ' : ''}${fontSize}px ${fontName}`;
+    addTextElement(textVal, canvasFont, defaultColor, posX, posY);
+    addToSnapSorts();
+});
 
 let updatePositions = (x, y) => {
     posX = x - 200;
@@ -237,4 +282,3 @@ bgImageUpload.addEventListener('change', function(event) {
         reader.readAsDataURL(file);
     }
 });
-

--- a/src/Scripts/Canvas.js
+++ b/src/Scripts/Canvas.js
@@ -282,3 +282,4 @@ bgImageUpload.addEventListener('change', function(event) {
         reader.readAsDataURL(file);
     }
 });
+


### PR DESCRIPTION
Fixes: #26 

## UI Changes
- Add a new "Add Text" button next to the existing controls
- Consider renaming the "Save" button to "Update" for clarity

## Benefits
- Users can create more complex designs with multiple text elements
- Increased flexibility and functionality of the text editor
- Improved user experience for creating diverse canvas designs

## Potential Challenges
- Ensuring smooth performance with multiple text elements
- Implementing an intuitive selection mechanism for editing specific text elements
- Updating the undo/redo functionality to work with multiple elements

## Additional Considerations
- We may need to update the drag functionality to work with individual text elements
- The capitalize/lowercase buttons should apply to the selected text element
- Consider adding a way to delete individual text elements

## Next Steps
1. Discuss the proposed changes with the team
2. Create a new branch for this feature
3. Implement the changes and test thoroughly
4. Update documentation to reflect the new functionality
5. Create a pull request for review

Please comment with any suggestions or concerns about this proposed feature.