### PR TITLE
Corrected the overflow

### DIFF
--- a/src/Styles/Style.css
+++ b/src/Styles/Style.css
@@ -6,12 +6,13 @@
 }
 
 body {
+    width: 100vw;
     height: 100vh !important;
 }
 
 /* Main canvas styles */
 #mainCanvas {
-    width: 70% !important;
+    width: 60% !important;
     height: auto;
     border: 1px solid gray;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
#46
- Changed the #body to make the width=vw(viewport width) 
- and the width in #mainCanvas(which was the problem) as it was exceeding the width of the viewport, causing a scroll bar to appear.
- now it is displayed within the viewport without any overflow.