### PR TITLE
Resolved issue: Contributing.md file redirect from README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Thank you to all the amazing contributors who have made this project possible! ð
 
 ## Contributing ðŸ’¡
 
-We welcome all contributions to improve **Canvas Editor**! If you'd like to contribute, please follow the [Contributing.md](./CONTRIBUTING.md) to get started.
-
+We welcome all contributions to improve **Canvas Editor**! If you'd like to contribute, please follow the [Contributing.md](./Contributing.md) to get started.
+<!-- Comment: The file name provided here was wrong(CONTRIBUTING.md instead of Contributing.md) due to which the redirect was showing an error. -->
 ---
 


### PR DESCRIPTION
## Issue #133  : Contributing.md not linked in README.md file. [SOLVED]

## Type of PR
- [X] Bug Fix

## Description
![image](https://github.com/user-attachments/assets/9d64c45e-082d-4b40-80d9-b89ffc8ad5cf)

The Contributing.md file in the code was previously leading to an error (as shown in the image under the Before section). I have resolved this issue (refer to the image under the After section) and added comments to document the changes made.

**Before:** 
![image](https://github.com/user-attachments/assets/99e6f59e-bd2f-4f66-a381-5f6d111bf8c2)

- The hyperlink was showing error due to wrong file mentioned in code (CONTRIBUTING.md)

**After:**
![image](https://github.com/user-attachments/assets/05ea1167-7157-4efd-a07a-9a6372aa6436)

- Issue resolved by changing the destination file to Contributing.md as present in the repository.