### PR TITLE
Issue #148 : fixed unvisible texts in canvas editor 

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,22 +121,22 @@
             <div class="p-3 bg-light rounded shadow">
                 <form id="userForm" class="d-flex flex-column">
                     <div class="d-flex gap-3 mb-2">
-                        <label for="textSize" class="text-dark">Size:</label>
+                        <label for="textSize" class="text-white">Size:</label>
                         <select name="tSize" class="form-select" id="textSize">
                             <option value="20">20</option>
                             <option value="30">30</option>
                             <option value="40">40</option>
                         </select>
-                        <label for="colorPicker" class="text-dark">Color:</label>
+                        <label for="colorPicker" class="text-white">Color:</label>
                         <input type="color" name="colorPicker" class="form-control" id="colorPicker">
                     </div>
                     <div class="d-flex row gap-3">
                         <div class="col-sm-6">
-                            <label for="bgImageUpload" class="text-dark">Background Image:</label>
+                            <label for="bgImageUpload" class="text-white">Background Image:</label>
                             <input type="file" id="bgImageUpload" accept="image/*">
                         </div>
                         <div class="col-sm-6">
-                            <label for="bgColorPicker" class="text-dark">Background Color:</label>
+                            <label for="bgColorPicker" class="text-white">Background Color:</label>
                             <input type="color" id="bgColorPicker" class="form-control" value="#f0f0f0">
                         </div>
                     </div>


### PR DESCRIPTION
Fixes #148 


Before the texts in Canvas Editor were not visible due to similar background color and text color. 
I have fixed unvisible Texts issue in Canvas Pallet.
(labels: gssoc-extended, hacktoberfest-accepted)

![image](https://github.com/user-attachments/assets/c6a67b9e-7ec8-44fb-b927-779e29b46f37)
