### PR TITLE
Modified the navigation tab to highlight only the current tab.

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,7 +210,7 @@
        <div class="row">
             <ul class="nav nav-tabs">
                 <li class="nav-item">
-                  <a class="nav-link active" aria-current="page" href="#">Home</a>
+                  <a class="nav-link" aria-current="page" href="#">Home</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="about-us.html">About Us</a>


### PR DESCRIPTION
Fixes #114


Enhanced the navigation tabs by ensuring only the active tab is highlighted, improving the user experience by clearly indicating the current section.

Branch name : Activetab


fix:        Modified line number 213 by removing the default active class from home tab



![{0B845A53-3260-4E1C-A3C3-FFA709C1F216}](https://github.com/user-attachments/assets/81188937-ec9d-4ce9-b85f-dde18f812e4b)

Please let me know if the changes meet your expectations or if any further modifications are needed. I'm eager to make adjustments as necessary.