### PR TITLE
Add Contributor Page to Display Project Contributors

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -49,6 +49,7 @@
                 <a href="about-us.html">About</a>
                 <a href="#blogs">Blogs</a>
                 <a href="index.html#mainCanvas">Draw</a>
+                <a href="contributors.html">Contributors</a>
             </div>
         </nav>
     </header>

--- a/contributors.html
+++ b/contributors.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contributors Page</title>
+    <style>
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(to right, #74ebd5, #acb6e5);
+            margin: 0;
+            padding: 0;
+            color: #2c3e50;
+        }
+
+        h1 {
+            text-align: center;
+            color: #ffffff;
+            margin-top: 50px;
+            font-size: 42px;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+        }
+
+        .container {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: 30px;
+            padding: 40px;
+        }
+
+        .contributor-card {
+            background: linear-gradient(135deg, #f3ec78, #af4261);
+            border-radius: 15px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+            overflow: hidden;
+            transition: transform 0.3s, box-shadow 0.3s;
+            width: 280px;
+            text-align: center;
+            color: #ffffff;
+        }
+
+        .contributor-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+        }
+
+        .contributor-photo {
+            width: 100%;
+            height: 200px;
+            object-fit: cover;
+            background-color: #ffffff;
+        }
+
+        .contributor-info {
+            padding: 20px;
+        }
+
+        .contributor-name {
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 15px;
+            text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.2);
+        }
+
+        .contributor-links {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 10px;
+        }
+
+        .contributor-links a {
+            color: #ffffff;
+            font-size: 18px;
+            text-decoration: none;
+            background: linear-gradient(45deg, #74ebd5, #acb6e5);
+            padding: 8px 15px;
+            border-radius: 25px;
+            transition: background 0.3s, transform 0.3s;
+        }
+
+        .contributor-links a:hover {
+            background: linear-gradient(45deg, #acb6e5, #74ebd5);
+            transform: scale(1.1);
+        }
+
+        footer {
+            text-align: center;
+            padding: 20px;
+            background-color: #2c3e50;
+            color: #ecf0f1;
+            margin-top: 50px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Meet Our Amazing Contributors</h1>
+    <div class="container">
+        <!-- Contributor 1 -->
+        <div class="contributor-card">
+            <img class="contributor-photo" src="https://via.placeholder.com/250x200/74ebd5/ffffff?text=Contributor+1" alt="Contributor 1 Photo">
+            <div class="contributor-info">
+                <div class="contributor-name">kjh</div>
+                <div class="contributor-links">
+                    <a href="https://github.com/johndoe" target="_blank">GitHub</a>
+                    <a href="https://linkedin.com/in/johndoe" target="_blank">LinkedIn</a>
+                </div>
+            </div>
+        </div>
+
+        <!-- Contributor 2 -->
+        <div class="contributor-card">
+            <img class="contributor-photo" src="https://via.placeholder.com/250x200/acb6e5/ffffff?text=Contributor+2" alt="Contributor 2 Photo">
+            <div class="contributor-info">
+                <div class="contributor-name">abc</div>
+                <div class="contributor-links">
+                    <a href="https://github.com/janesmith" target="_blank">GitHub</a>
+                    <a href="https://linkedin.com/in/janesmith" target="_blank">LinkedIn</a>
+                </div>
+            </div>
+        </div>
+
+        <!-- Contributor 3 -->
+        <div class="contributor-card">
+            <img class="contributor-photo" src="https://via.placeholder.com/250x200/ffcc70/ffffff?text=Contributor+3" alt="Contributor 3 Photo">
+            <div class="contributor-info">
+                <div class="contributor-name">def</div>
+                <div class="contributor-links">
+                    <a href="https://github.com/michaeljohnson" target="_blank">GitHub</a>
+                    <a href="https://linkedin.com/in/michaeljohnson" target="_blank">LinkedIn</a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer>
+        &copy; 2024 Canvas-Editor | All rights reserved
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Issue No - #115 
## Description
This PR introduces a new contributors.html page to showcase the contributors to the project. The page uses a responsive design and includes the following:
## Features Added : 

-  Created a dedicated contributors page with a grid layout.
- Added dummy data with placeholder images, names, GitHub IDs, and LinkedIn profile links for contributors.
- Implemented a clean, modern design with hover effects and background gradients to enhance visual appeal.
