### PR TITLE
🛠️FIX : Contact Us page - Name field validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,7 +726,9 @@ h2{
                         <div class="col-md-4">
                             <div class="form-floating">
                                 <input type="text" class="form-control" id="name" name="name" placeholder="Your Name"
-                                    required>
+                                    required pattern="[a-zA-Z ]+"
+                                oninvalid="this.setCustomValidity('Numbers and Symbols are not allowed')"
+                                oninput="this.setCustomValidity('')">
                                 <label for="name">Your Name</label>
                             </div>
                         </div>


### PR DESCRIPTION
### Title of the Pull Request
- [x] Have you renamed the PR Title in a meaningful way?



### Related Issue
Closes: #652 

### Description
The "Name" field on the **_Contact Us_** section should only accept alphabetical letters (a-z, A-Z). Currently, the field allows users to input symbols and special characters, which may lead to invalid or spam submissions.


## How Has This Been Tested? ⚙️

1. Go to the Contact Us section.
2. Type numbers and symbols in the Name field.
3. See the alert message.

## Screenshots 📷

Before
![image](https://github.com/user-attachments/assets/cdccab98-08bc-49a4-bdc1-66b229a411e6)

After
![image](https://github.com/user-attachments/assets/56d0c0f7-87a0-4eee-b6b9-fd7d27fcd93c)



### Type of change
What sort of changes have you made:

- [x] Bug fix (non-breaking change which fixes an issue)


### Checklist

- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.
- [x] I have resolved all merge conflicts.