### PR TITLE
FIX: Commented line is visible on Sign up page

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -152,9 +152,7 @@
                 color: #302f2f;
             }
         }
-    </style>
-</head>
-<body>
+
 
         /* Circle styles */
         .circle {


### PR DESCRIPTION
### Title of the Pull Request
- [x] Have you renamed the PR Title in a meaningful way?



### Related Issue

Closes: #898 

### Description
A Commented line was visible on the Signup page above the navbar, now it is gone.


## How Has This Been Tested? ⚙️

1. Go to Sign up page and see there is no line above the nav bar.


## Screenshots 📷
Before
![image](https://github.com/user-attachments/assets/1087bb06-2079-4287-a5d4-7884edcb3c9f)

After
![image](https://github.com/user-attachments/assets/fdf7ed35-4002-4c01-ac94-32726f716ce5)

### Type of change
What sort of changes have you made:


- [x] Bug fix (non-breaking change which fixes an issue)

# Priority 
High


### Checklist

- [x] My code follows the code style of this project.
- [x] I have followed the contribution guidelines
- [x] I have performed a self-review of my own code.
- [x] I have ensured my changes don't generate any new warnings or errors.
- [x] I have updated the documentation (if necessary).
- [x] I have resolved all merge conflicts.