### PR TITLE
contributors page dark mode toggle

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -47,6 +47,15 @@
         align-items: center;
         flex-wrap: wrap;
         border-bottom: none;
+
+        position: fixed; 
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100px; 
+        z-index: 100;
+        padding-right: 40px; 
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); 
       }
 
       /* Styling individual links in the navbar */
@@ -202,6 +211,9 @@
           <a href="signup.html">Sign Up</a>
           <a href="login.html">Login</a>
         </div>
+        <div class="toggle-container aos-init aos-animate" data-aos="fade-down">
+          <input id="themeToggle" class="toggle" type="checkbox">
+        </div>
       </nav>
       
       <div class="containerm">
@@ -215,9 +227,6 @@
     </video>
     
     <div class="container">
-      <div class="toggle-container aos-init aos-animate" data-aos="fade-down">
-        <input id="themeToggle" class="toggle" type="checkbox">
-      </div>
       
       </header>
       <h1 class="title">Our Contributors</h1>

--- a/src/Styles/contributor.css
+++ b/src/Styles/contributor.css
@@ -20,6 +20,7 @@ body{
   display: inline-block;
   font-size: 3em;
   margin-bottom: 20px;
+  margin-top: 100px;
   padding: 10px;
   color: #2e06fb;
   text-shadow: 1px 1px 2px rgb(60, 0, 255), 0 0 1em rgba(0, 213, 255, 0.617),
@@ -140,9 +141,12 @@ body{
 /* dark mode */
 /* Toggle button styles */
 .toggle-container {
-  position: fixed; /* Change this as needed for positioning */
-  top: 25px;
-  right: 40px;
+  position: relative;
+  z-index: 101;
+  width: 50px;
+  height: 25px;
+  top:-27px;
+  left:20px;
 }
 
 .toggle {
@@ -265,7 +269,9 @@ body.dark-mode .contributor-card p {
 body.dark-mode .contributor-card h2 {
   color: white;
 }
-
+body.dark-mode .title{
+  color: #f77ee1;
+}
 /* Mobile-specific adjustments: One large card per row */
 @media (max-width: 768px) {
   .contributor-container {


### PR DESCRIPTION
### Title of the Pull Request
- [X] Have you renamed the PR Title in a meaningful way?
<!-- 
Examples of good PR titles:

build:      (for build related changes)
chore:      (for updating task runner configs etc; no production code change)
docs:       (for documentation changes)
feat:       (for new feature)
fix:        (for bug fixes)
perf:       (for performance improvements)
refactor:   (for refactoring code; no production code change)
revert:     (when reverting changes)
style:      (changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc))
test:       (when adding missing tests)
-->


### Related Issue
<!-- Replace `<issue number>` with the issue number which is fixed in this PR -->
Closes: #952 

### Description
<!-- Describe the changes you made in this pull request in DETAILS-->
As it can be seen in issue, that the toggle for dark mode position was not aligned properly. While scrolling, it was getting displaced from navbar, not only that, it was getting hidden behind the content , that is contributors.
Now the toggle for dark mode is placed properly in navbar. Also title "our contributors" was not properly visible in dark mode which is now visible

## How Has This Been Tested? ⚙️
By running in live server
<!-- Describe how it has been tested & how have you verified the changes made
-->

## Screenshots 📷
<!-- Add screenshots if applicable -->
Before:
<img width="1339" alt="Screenshot 2024-10-30 at 4 26 37 PM" src="https://github.com/user-attachments/assets/82351e3a-a2bf-4571-a28a-d7facdc0d717">
<img width="1235" alt="Screenshot 2024-10-30 at 4 26 45 PM" src="https://github.com/user-attachments/assets/a2778845-6309-4978-8149-541bc266686b">
After:
<img width="1300" alt="Screenshot 2024-10-30 at 4 26 53 PM" src="https://github.com/user-attachments/assets/93724e00-a403-4830-a1b4-5f28357fcad7">
<img width="1257" alt="Screenshot 2024-10-30 at 4 26 59 PM" src="https://github.com/user-attachments/assets/334920b0-fa50-4264-bbd5-82d18292eea0">


### Type of change
What sort of changes have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [X] My code follows the code style of this project.
- [X] I have followed the contribution guidelines
- [X] I have performed a self-review of my own code.
- [X] I have ensured my changes don't generate any new warnings or errors.
- [X] I have updated the documentation (if necessary).
- [X] I have resolved all merge conflicts.