### PR TITLE
Center-align social media icons on Contributors page

### DIFF
--- a/contributors.html
+++ b/contributors.html
@@ -465,6 +465,7 @@
             display: flex;
             flex-direction: column;
             gap: 0.5rem;
+            align-items: center;
         }
 
         .credit a {


### PR DESCRIPTION
# Pull Request Template for Vehigo

## 1. Title
fix: center-align social media icons on Contributors page

## 2. Description
This PR updates the layout of the Contributors page to ensure that the social media icons are horizontally centered.  
Previously, the icons were left-aligned, which created an uneven appearance and reduced visual balance.  
The fix improves the design consistency and aligns with common UI patterns.

## 3. Related Issues
Closes #1335

## 4. Changes Made
- [x] Updated CSS to center-align social media icons within their container.
- [x] Verified responsiveness across desktop and mobile views.
- [x] Ensured no other layout elements were unintentionally shifted.

