### PR TITLE
Added video modal and open documentation in new tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "visi.js",
   "scripts": {
     "start": "node visi.js",
+    "dev": "node visi.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
   "license": "ISC"
-}
+}  

--- a/tutorial.html
+++ b/tutorial.html
@@ -549,9 +549,10 @@
                 <li>Creating a New Canvas: Learn how to set custom dimensions and resolutions.</li>
             </ul>
             <div class="button-group">
-                <span class="button">Watch Video Tutorial</span>
-                <span class="button">Read Documentation</span>
-            </div>
+    <span id="videoTutorial" class="button">Watch Video Tutorial</span>
+    <span id="readDocs" class="button">Read Documentation</span>
+</div>
+
         </section>
 
         <section class="tutorial-section">
@@ -667,6 +668,54 @@
         // Cursor Effect (placeholder, as actual implementation depends on more JS)
     </script>
     <script src="src/Scripts/dropdown.js"></script>
+<!-- Modal for Video -->
+<div id="modalOverlay" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; 
+    background:rgba(0,0,0,0.7); justify-content:center; align-items:center; z-index:2000;">
+    <div id="modalContent" style="background:#1a1d23; padding:20px; border-radius:12px; max-width:800px; width:90%; position:relative;">
+        <span id="closeModal" style="position:absolute; top:10px; right:15px; cursor:pointer; font-size:24px; color:white;">&times;</span>
+        <div id="modalBody">
+            <!-- Video will appear here -->
+        </div>
+    </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    const modal = document.getElementById('modalOverlay');
+    const modalBody = document.getElementById('modalBody');
+    const closeModal = document.getElementById('closeModal');
+
+    // Watch Video Tutorial: Creating a New Canvas
+    document.getElementById('videoTutorial').addEventListener('click', () => {
+        modalBody.innerHTML = `
+            <iframe width="100%" height="500" src="https://www.youtube.com/embed/czq6p99Jafc" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        `;
+        modal.style.display = 'flex';
+    });
+
+    // Read Documentation: Open in new tab
+    document.getElementById('readDocs').addEventListener('click', () => {
+        window.open('https://www.canva.com/en_au/help/design-from-scratch/#:~:text=On%20the%20bottom%20corner%20of,the%20width%20of%20your%20banner.', '_blank');
+    });
+
+    // Close modal when clicking ×
+    closeModal.addEventListener('click', () => {
+        modal.style.display = 'none';
+        modalBody.innerHTML = '';
+    });
+
+    // Close modal when clicking outside content
+    modal.addEventListener('click', (e) => {
+        if (e.target === modal) {
+            modal.style.display = 'none';
+            modalBody.innerHTML = '';
+        }
+    });
+});
+</script>
+
+
+
 </body>
 
 </html>


### PR DESCRIPTION
Title of the Pull Request
✨ feat: Add interactive video modal and documentation button for Getting Started section


🎬 Watch Video Tutorial: Opens the YouTube tutorial (https://www.youtube.com/watch?v=czq6p99Jafc) inside a sleek modal overlay for an immersive learning experience.
📖 Read Documentation: Opens the official Canva documentation (https://www.canva.com/en_au/help/design-from-scratch/) in a new browser tab, bypassing iframe restrictions.

✅ Modal Enhancements:
Click × or outside the modal to close.
Fully responsive and consistent with Canvas Editor's theme and gradient styling.
These updates make the tutorial section more interactive and user-friendly, helping new users get started quickly with creating a new canvas.

How Has This Been Tested? ⚙️
Verified that Watch Video Tutorial launches the correct video in a modal.
Verified that Read Documentation opens the Canva page in a new browser tab.
Confirmed that the modal closes properly via × button and click outside.
Tested across multiple browsers: Chrome, Edge, Firefox.

Ensured no console errors or layout breaks occur.

Checklist ✅

 My code follows the project’s code style and conventions.
 I have followed the contribution guidelines.
 I have tested my changes and ensured they work correctly.
 I have updated or added relevant documentation.
 All merge conflicts have been resolved.